### PR TITLE
Update docker-image.yml

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  pull_request_target:
+    branches: [ main ]
   workflow_dispatch:
 env:
   # Last fragment of identifier of the docker image
@@ -21,7 +23,7 @@ jobs:
     steps:
       - name: Exit if pull request is from a fork
         run: |
-          if [ "${{ github.event_name }}" == "pull_request" ] && [ "${{ github.event.pull_request.head.repo.name }}" != "${{ github.event.repository.name }}" ]; then
+          if [ "${{ github.event_name }}" == "pull_request_target" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.repository.full_name }}" ]; then
             echo "Skipping workflow as this pull request is from a fork."
             exit 78
           fi


### PR DESCRIPTION
@blcham 
- pull requests will have the event name equal to "pull_request_target"
  `github.event_name == "pull_request_target"`
- If the pull request is created from a fork repository than the head repo full name will be different from the base repo full name and from repository full name:
  `github.event.pull_request.head.repo.fulle_name != github.event.repository.name`
  `github.event.pull_request.head.repo.fulle_name != github.event.pull_request.base.repo.fulle_name`

  `github.event.pull_request.base.repo.fulle_name != github.event.repository.name`

Additionally I found a way to print all context information when the action runs:
```
jobs:
  one:
    runs-on: ubuntu-latest
    steps:
      - name: Dump GitHub context
        env:
          GITHUB_CONTEXT: ${{ toJSON(github) }}
        run: echo "$GITHUB_CONTEXT"
```

taken from [stackoverflow - Complete list of github actions contexts](https://stackoverflow.com/questions/70104600/complete-list-of-github-actions-contexts) 