### PR TITLE
Fix exporting records to excel

### DIFF
--- a/src/main/java/cz/cvut/kbss/study/service/ExcelRecordConverter.java
+++ b/src/main/java/cz/cvut/kbss/study/service/ExcelRecordConverter.java
@@ -127,7 +127,7 @@ public class ExcelRecordConverter {
             r.createCell(10).setCellValue(rec.getFuselage());
             r.createCell(11).setCellValue(rec.getFailDate());
             r.createCell(12).setCellValue(rec.getFlightHours());
-            r.createCell(13).setCellValue(rec.getNumberOfAirframeOverhauls());
+            Optional.ofNullable(rec.getNumberOfAirframeOverhauls()).ifPresent( i -> r.createCell(13).setCellValue(i));
             r.createCell(14).setCellValue(rec.getClassificationOfOccurrence());
             r.createCell(15).setCellValue(rec.getFailureAscertainmentCircumstances());
             r.createCell(16).setCellValue(rec.getRepeatedFailure());
@@ -136,7 +136,7 @@ public class ExcelRecordConverter {
             r.createCell(19).setCellValue(rec.getMission());
             r.createCell(20).setCellValue(rec.getRepair());
             r.createCell(21).setCellValue(rec.getRepairDuration());
-            r.createCell(22).setCellValue(rec.getAverageNumberOfMenDuringRepairment());
+            Optional.ofNullable(rec.getAverageNumberOfMenDuringRepairment()).ifPresent( i -> r.createCell(22).setCellValue(i));
             r.createCell(23).setCellValue(rec.getFailureDescription());
             r.createCell(24).setCellValue(rec.getDescriptionOfCorrectiveAction());
             r.createCell(25).setCellValue(rec.getAc_compName());

--- a/src/main/resources/query/find-raw-records.sparql
+++ b/src/main/resources/query/find-raw-records.sparql
@@ -28,7 +28,7 @@ SELECT ?r (?r as ?uri)
         FILTER(?s2 != ?s1)
         ?s2 doc:has_related_question ?fhaEventQ.
         ?fhaEventQ form:has-question-origin ?fhaEventQuestionOrigin.
-        FILTER(contains(str(?fhaEventQuestionOrigin), "http://vfn.cz/ontologies/ava-study/model/fha-event-"))
+        FILTER(contains(str(?fhaEventQuestionOrigin), "http://vfn.cz/ontologies/ava-study/model/fha-event"))
 
         ?s1 doc:has_related_question ?FUSq.
         ?FUSq form:has-question-origin avamod:fuselage-no.
@@ -181,8 +181,9 @@ SELECT ?r (?r as ?uri)
             OPTIONAL {
                 #avamod:number-of-overhauls-of-defective-equipment
                 ?numberOfOverhaulsOfDefectiveEquipmentQ doc:has_answer ?numberOfOverhaulsOfDefectiveEquipmentA.
-                ?numberOfOverhaulsOfDefectiveEquipmentA doc:has_data_value ?numberOfOverhaulsOfDefectiveEquipment.# TODO - transform to more suitable datatype
-                FILTER(str(spif:trim(?numberOfOverhaulsOfDefectiveEquipment)) != "" )
+                ?numberOfOverhaulsOfDefectiveEquipmentA doc:has_data_value ?numberOfOverhaulsOfDefectiveEquipmentStr.# TODO - transform to more suitable datatype
+                FILTER(str(spif:trim(?numberOfOverhaulsOfDefectiveEquipmentStr)) != "" )
+                BIND(xsd:integer(str(spif:trim(?numberOfOverhaulsOfDefectiveEquipmentStr))) as ?numberOfOverhaulsOfDefectiveEquipment)
         #    }
         # 	 OPTIONAL{
         #        #avamod:serial-no-of

--- a/src/main/resources/query/find-raw-records.sparql
+++ b/src/main/resources/query/find-raw-records.sparql
@@ -24,11 +24,14 @@ SELECT ?r (?r as ?uri)
     GRAPH ?r {
         ?r rm:has-question ?f.
         ?f doc:has_related_question ?s1.
-        ?f doc:has_related_question ?s2.
-        FILTER(?s2 != ?s1)
-        ?s2 doc:has_related_question ?fhaEventQ.
-        ?fhaEventQ form:has-question-origin ?fhaEventQuestionOrigin.
-        FILTER(contains(str(?fhaEventQuestionOrigin), "http://vfn.cz/ontologies/ava-study/model/fha-event"))
+
+        OPTIONAL{
+            ?f doc:has_related_question ?s2.
+            FILTER(?s2 != ?s1)
+            ?s2 doc:has_related_question ?fhaEventQ.
+            ?fhaEventQ form:has-question-origin ?fhaEventQuestionOrigin.
+            FILTER(contains(str(?fhaEventQuestionOrigin), "http://vfn.cz/ontologies/ava-study/model/fha-event"))
+        }
 
         ?s1 doc:has_related_question ?FUSq.
         ?FUSq form:has-question-origin avamod:fuselage-no.
@@ -197,6 +200,7 @@ SELECT ?r (?r as ?uri)
                 FILTER(str(spif:trim(?notes)) != "" )
             }
             OPTIONAL{
+                FILTER(BOUND(?s2) && BOUND(?fhaEventQ))
                 #avamod:fha-event
                 ?fhaEventQ doc:has_answer ?fhaEventA.
                 ?fhaEventA doc:has_object_value ?fhaEvent.


### PR DESCRIPTION
@blcham 
Fixes kbss-cvut/record-manager-ui#185

Changes variable `numberOfOverhaulsOfDefectiveEquipment` type string to integer to so that it could be mapped to its corresponding integer field in JOPA entity.