### PR TITLE
New roles for answer feedback and question hint features

### DIFF
--- a/src/main/java/cz/cvut/kbss/study/model/Role.java
+++ b/src/main/java/cz/cvut/kbss/study/model/Role.java
@@ -66,8 +66,16 @@ public enum Role {
     @Individual(iri = Vocabulary.s_i_read_statistics_role)
     readStatistics(SecurityConstants.readStatistics, Vocabulary.s_i_read_statistics_role),
 
+    @Individual(iri = Vocabulary.s_i_read_answer_feedback_role)
+    readAnswerFeedback(SecurityConstants.readAnswerFeedback, Vocabulary.s_i_read_answer_feedback_role),
+
+    @Individual(iri = Vocabulary.s_i_read_question_hint_role)
+    readQuestionHint(SecurityConstants.readQuestionHint, Vocabulary.s_i_read_question_hint_role),
+
     @Individual(iri = Vocabulary.s_i_impersonate_role)
     impersonate(SecurityConstants.impersonate, Vocabulary.s_i_impersonate_role);
+
+
 
     private final String iri;
 

--- a/src/main/java/cz/cvut/kbss/study/security/SecurityConstants.java
+++ b/src/main/java/cz/cvut/kbss/study/security/SecurityConstants.java
@@ -67,4 +67,8 @@ public class SecurityConstants {
 
     public static final String readStatistics = "readStatistics";
 
+    public static final String readAnswerFeedback = "readAnswerFeedback";
+
+    public static final String readQuestionHint = "readQuestionHint";
+
 }

--- a/src/main/resources/model.ttl
+++ b/src/main/resources/model.ttl
@@ -304,6 +304,14 @@ rm:read-statistics-role rdf:type owl:NamedIndividual, rm:role;
         rdfs:label "read statistics"@en ;
         rdfs:comment "Allows user to view statistical reports about the system’s data."@en .
 
+rm:read-answer-feedback-role rdf:type owl:NamedIndividual, rm:role;
+        rdfs:label "read answer feedback"@en ;
+        rdfs:comment "Allows users to view feedback for entered answers."@en .
+
+rm:read-question-hint-role rdf:type owl:NamedIndividual, rm:role;
+        rdfs:label "read question hint"@en ;
+        rdfs:comment "Allows users to reveal hint for question."@en .
+
 rm:impersonate-role rdf:type owl:NamedIndividual, rm:role;
         rdfs:label "impersonate user"@en .
 


### PR DESCRIPTION
Added two new roles to support learning-related features:
- `readAnswerFeedback` allows users to view correctness feedback for entered answers
- `readQuestionHint` allows users to reveal hints for questions